### PR TITLE
Add GPG sign to the github action commits

### DIFF
--- a/.github/workflows/toulouse-bl-mirror.yml
+++ b/.github/workflows/toulouse-bl-mirror.yml
@@ -61,7 +61,16 @@ jobs:
         id: get-date-time
         run: echo "DT=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> $GITHUB_OUTPUT
 
-      - name: Commit to repo
-        uses: stefanzweifel/git-auto-commit-action@v4
+      - name: Import GPG key
+        uses: crazy-max/ghaction-import-gpg@v5
         with:
-          commit_message: "[Bot] Update Blacklist (${{ steps.get-date-time.outputs.DT }})"
+          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
+          passphrase: ${{ secrets.GPG_PASSWORD }}
+          git_user_signingkey: true
+          git_commit_gpgsign: true
+
+      - name: Sign commit and push changes
+        run: |
+          git add .
+          git commit -S -m "[Bot] Update Blacklist (${{ steps.get-date-time.outputs.DT }})"
+          git push


### PR DESCRIPTION
Before merge this PR we need to add the 2 repository secrets containing the GPG Priv key ( `GPG_PRIVATE_KEY`) and Passphrase (`GPG_PASSWORD`) as described [here](https://github.com/crazy-max/ghaction-import-gpg#prerequisites)

I've tested it with my personal key and it works, but i guess we could generate one for the NS organization.